### PR TITLE
feat: 第三方组件生态地基 — 扩展 API hygiene 修复 + 立项

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "external-api-probe"
+version = "0.0.0"
+dependencies = [
+ "ratatui-kit",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "3"
-members = ["crates/ratatui-kit", "crates/ratatui-kit-macros"]
+members = [
+    "crates/ratatui-kit",
+    "crates/ratatui-kit-macros",
+    # 宏 hygiene 护栏:只依赖 ratatui-kit(不依赖 ratatui/crossterm)的外部作者视角 crate,
+    # 随 --workspace 自动编译;宏展开一旦回退成裸 ratatui::/crossterm:: 即编译失败。
+    "crates/external-api-probe",
+]
 
 [package]
 name = "ratatui-kit-examples"

--- a/EXTENSION_API.md
+++ b/EXTENSION_API.md
@@ -1,0 +1,94 @@
+# Extension API Surface
+
+This document defines the **public API surface that `ratatui-kit` commits to** for
+third-party component / hook authors. If you are building a `ratatui-kit-<name>`
+crate, depend only on the items listed under *Stable surface*.
+
+> 本文件面向第三方组件作者,列出框架承诺遵守 semver 的公共 API。标注 `#[doc(hidden)]`
+> 的项(宏协议 + 内部实现)即使是 `pub` 也**不属于**稳定面,不要直接依赖。
+
+## Stability policy
+
+- **`0.x` semver**: a breaking change to any *Stable surface* item bumps the **minor**
+  version; purely additive changes go in a **patch**.
+- **Depend with a range**, e.g. `ratatui-kit = ">=0.7, <0.8"`, matching the surface
+  version you build against.
+- **Get `ratatui` / `crossterm` types through the re-exports** — `ratatui_kit::ratatui`
+  and `ratatui_kit::crossterm` — instead of adding a direct dependency. This avoids a
+  second, possibly incompatible, copy of `ratatui` in your tree.
+- Items marked `#[doc(hidden)]` are `pub` only because the macros or the runtime need
+  them to be; they are **not** covered by the policy above and may change at any time.
+
+## Stable surface (semver-guaranteed)
+
+### Component contract
+`Component`, `ComponentUpdater`, `ComponentDrawer`, `Components` (+ `get_constraints`),
+`LayoutStyle`, `NoProps`, `Props`.
+
+### Elements
+`Element`, `AnyElement`, `ElementExt` (`fullscreen` / `render_loop`).
+
+### Hooks
+`Hooks`, `Hook`, `Hooks::use_hook`, and the built-in hook traits:
+`UseState`, `UseContext`, `UseFuture`, `UseMemo`, `UseEffect` / `UseAsyncEffect`,
+`UseAsyncState`, `UseInsertBefore`, `UseTerminalSize` / `UsePreviousSize`,
+`UseExit`, `UseOnDrop`, `UseInputLayer`, `UseEventHandler`,
+and feature-gated `UseRouter` (`router`), `UseAtom` (`atom`).
+
+### State
+`State` (and the underlying `ReactiveHandle` + its `ReactiveRef` / `ReactiveMutRef` /
+`ReactiveMutNoUpdate` guards and operator overloads), `AsyncState`.
+
+### Context & events
+`Context`, `ContextStack` (opaque token — pass it by name, do not construct),
+`Handler`, `EventResult`, `EventPriority`, `EventScope`, `EventOptions`, `InputLayer`,
+`SystemContext` (its `exit()` is the escape hatch behind `use_exit`).
+
+### Routing (feature: `router`)
+`Navigate` (returned by `use_navigate`).
+
+### Terminal
+`Terminal`, `TerminalImpl`, `CrossTerminal` — backend / custom render-loop entry points.
+
+### Global state (feature: `atom`)
+`Atom`, `AtomState` (+ its guards).
+
+### Macros
+`element!`, `#[component]`, `#[derive(Props)]`, `#[with_layout_style]`,
+and `routes!` (feature: `router`).
+
+## Not part of the surface
+
+These are `pub` but `#[doc(hidden)]` — do not depend on them.
+
+### Macro protocol (referenced by macro expansion only)
+`ElementType`, `ExtendWithElements`, `extend_with_elements`, `ElementKey`,
+`ElementRepr`, `WidgetAdapter*`, `StatefulWidgetAdapter*`, `Route::new`.
+
+### Internal implementation
+`AnyComponent`, `InstantiatedComponent`, `AnyProps`, `Tree`,
+`Notifier` / `ReactiveValue` / `SingleWaker` / `WakerMap`, `LayerId`,
+`UseEffectImpl` / `UseAsyncEffectImpl` / `UseFutureImpl` / `UseMemoImpl` /
+`UsePreviousSizeImpl`, `UpdaterTerminal`.
+
+## Authoring checklist
+
+- Depend only on *Stable surface* items; reach `ratatui` / `crossterm` via
+  `ratatui_kit::ratatui` / `ratatui_kit::crossterm`.
+- Macros expand to absolute `::ratatui_kit::…` paths — this works as long as the
+  dependency keeps the crate name `ratatui-kit` (not renamed via `cargo`).
+- `#[component]` functions are **transparent-layout wrappers**: put layout props on the
+  **returned root element**, not on the wrapper.
+- Feature-gate any heavy dependency (`optional = true` + a feature); keep default
+  features minimal.
+- Panic / expect / error messages shown to library users are **English**.
+- All examples and doctests must compile — this is the regression baseline.
+
+## Guardrail
+
+The workspace crate `crates/external-api-probe` depends **only** on `ratatui-kit`
+(deliberately not on `ratatui` / `crossterm`) and exercises the macros + a manual
+`Component` + a custom `Hook`. It compiles under `--workspace`, so if a macro ever
+expands to a bare `ratatui::` / `crossterm::` path (or otherwise leaks a non-exported
+item), it fails to compile and CI goes red. `trybuild` cannot catch this — its temporary
+crate mirrors the tested crate's `ratatui` / `crossterm` dependencies.

--- a/crates/external-api-probe/Cargo.toml
+++ b/crates/external-api-probe/Cargo.toml
@@ -1,0 +1,12 @@
+# 宏 hygiene 护栏 crate:只依赖 ratatui-kit(刻意不依赖 ratatui/crossterm),
+# 模拟第三方组件作者的视角。随 --workspace 自动编译;不发布。
+[package]
+name = "external-api-probe"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+
+[dependencies]
+ratatui-kit = { path = "../ratatui-kit" }

--- a/crates/external-api-probe/src/lib.rs
+++ b/crates/external-api-probe/src/lib.rs
@@ -1,0 +1,86 @@
+//! 宏 hygiene 回归护栏 / 最小「外部组件 crate」示例。
+//!
+//! 这个 crate **只**依赖 `ratatui-kit`(刻意不依赖 `ratatui`/`crossterm`),模拟第三方
+//! 组件作者的视角:只通过公共扩展 API 定义组件与自定义 hook。它随 `--workspace` 自动
+//! 编译,因此一旦过程宏展开回退成裸 `ratatui::`/`crossterm::` 路径(外部作用域解析不到),
+//! 这里就会编译失败、CI 变红。
+//!
+//! 为什么不用 trybuild:`tests/ui/pass` 的临时 crate 会 mirror 被测 crate 的
+//! `ratatui`/`crossterm` 依赖(作用域里有裸 `ratatui`),故抓不到 hygiene 回退。
+//!
+//! 覆盖:`#[with_layout_style]` + `#[derive(Props)]` + 手动 `impl Component` +
+//! `#[component]` + `element!` + `use_state` + 自定义 `Hook` / `use_hook`。
+
+use ratatui_kit::prelude::*;
+use ratatui_kit::ratatui::layout::Direction;
+
+// ── 1) #[derive(Props)] + #[with_layout_style] + 带 children 的 Props ──────────
+#[with_layout_style]
+#[derive(Default, Props)]
+pub struct PanelProps<'a> {
+    pub title: String,
+    pub children: Vec<AnyElement<'a>>,
+}
+
+// ── 2) 手动 impl Component:验证 Component / ComponentUpdater / AnyElement /
+//        update_children / set_layout_style / layout_style() 都对外可达 ──────────
+pub struct Panel;
+
+impl Component for Panel {
+    type Props<'a> = PanelProps<'a>;
+
+    fn new(_props: &Self::Props<'_>) -> Self {
+        Self
+    }
+
+    fn update(
+        &mut self,
+        props: &mut Self::Props<'_>,
+        _hooks: Hooks,
+        updater: &mut ComponentUpdater,
+    ) {
+        updater.set_layout_style(props.layout_style());
+        updater.update_children(&mut props.children, None);
+    }
+}
+
+// ── 3) #[component] 函数组件 + element! + use_state + 自定义 hook ───────────────
+#[derive(Default, Props)]
+pub struct BadgeProps {
+    pub label: String,
+}
+
+#[component]
+pub fn Badge(props: &BadgeProps, mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+    let mut n = hooks.use_state(|| 0u32);
+    n += 1;
+    let ticks = hooks.use_tick();
+    let title = format!("{} #{} ({}t)", props.label, n.get(), ticks);
+    element! {
+        Panel(title: title, flex_direction: Direction::Vertical, gap: 1)
+    }
+}
+
+// ── 4) 自定义 hook:实现 Hook trait + 定义(未 seal 的)extension trait ───────────
+//        验证「外部无法用 private::Sealed,但仍能通过 use_hook 注册自定义 hook」。
+pub struct TickHook {
+    n: u32,
+}
+
+impl Hook for TickHook {
+    fn poll_change(&mut self, _cx: &mut std::task::Context) -> std::task::Poll<()> {
+        std::task::Poll::Pending
+    }
+}
+
+pub trait UseTick {
+    fn use_tick(&mut self) -> u32;
+}
+
+impl UseTick for Hooks<'_, '_> {
+    fn use_tick(&mut self) -> u32 {
+        let h = self.use_hook(|| TickHook { n: 0 });
+        h.n += 1;
+        h.n
+    }
+}

--- a/crates/ratatui-kit-macros/src/with_layout_style.rs
+++ b/crates/ratatui-kit-macros/src/with_layout_style.rs
@@ -52,23 +52,23 @@ pub fn impl_layout_style(
         .iter()
         .map(|field| match field.to_string().as_str() {
             "margin" => Field::parse_named
-                .parse2(quote! { pub margin: ratatui::layout::Margin })
+                .parse2(quote! { pub margin: ::ratatui_kit::ratatui::layout::Margin })
                 .unwrap(),
             "offset" => Field::parse_named
-                .parse2(quote! { pub offset: ratatui::layout::Offset })
+                .parse2(quote! { pub offset: ::ratatui_kit::ratatui::layout::Offset })
                 .unwrap(),
             "width" => Field::parse_named
-                .parse2(quote! { pub width: ratatui::layout::Constraint })
+                .parse2(quote! { pub width: ::ratatui_kit::ratatui::layout::Constraint })
                 .unwrap(),
             "height" => Field::parse_named
-                .parse2(quote! { pub height: ratatui::layout::Constraint})
+                .parse2(quote! { pub height: ::ratatui_kit::ratatui::layout::Constraint})
                 .unwrap(),
             "gap" => Field::parse_named.parse2(quote! { pub gap: i32 }).unwrap(),
             "flex_direction" => Field::parse_named
-                .parse2(quote! { pub flex_direction: ratatui::layout::Direction })
+                .parse2(quote! { pub flex_direction: ::ratatui_kit::ratatui::layout::Direction })
                 .unwrap(),
             "justify_content" => Field::parse_named
-                .parse2(quote! { pub justify_content: ratatui::layout::Flex })
+                .parse2(quote! { pub justify_content: ::ratatui_kit::ratatui::layout::Flex })
                 .unwrap(),
             _ => panic!("Unknown layout style field: {field}"),
         })

--- a/crates/ratatui-kit-macros/src/with_layout_style.rs
+++ b/crates/ratatui-kit-macros/src/with_layout_style.rs
@@ -109,6 +109,9 @@ pub fn impl_layout_style(
 
                 impl #impl_generics #struct_name #ty_generics #where_clause {
                     /// Returns the layout style based on the layout-related fields of this struct.
+                    // 字段全部被 with_layout_style 选中时 `..Default::default()` 是多余的;
+                    // 宏自带 allow,以免外部 crate(无 crate 级 allow)在 -D warnings 下报错。
+                    #[allow(clippy::needless_update)]
                     pub fn layout_style(&self) -> ::ratatui_kit::layout_style::LayoutStyle {
                         ::ratatui_kit::layout_style::LayoutStyle {
                             #(#layout_style_assignments,)*

--- a/crates/ratatui-kit/src/component/instantiated_component.rs
+++ b/crates/ratatui-kit/src/component/instantiated_component.rs
@@ -61,6 +61,7 @@ impl Components {
     }
 }
 
+#[doc(hidden)]
 pub struct InstantiatedComponent {
     key: ElementKey,
     hooks: Vec<Box<dyn AnyHook>>,

--- a/crates/ratatui-kit/src/component/mod.rs
+++ b/crates/ratatui-kit/src/component/mod.rs
@@ -110,6 +110,7 @@ pub trait Component: Any + Unpin {
     }
 }
 
+#[doc(hidden)]
 pub trait AnyComponent: Any + Unpin {
     fn update(&mut self, props: AnyProps, hooks: Hooks, updater: &mut ComponentUpdater);
 

--- a/crates/ratatui-kit/src/element/extend_with_elements.rs
+++ b/crates/ratatui-kit/src/element/extend_with_elements.rs
@@ -1,5 +1,6 @@
 use super::{AnyElement, Element, ElementType};
 
+#[doc(hidden)]
 pub trait ExtendWithElements<T> {
     fn extend_with_elements<E: Extend<T>>(self, dest: &mut E);
 }
@@ -36,6 +37,7 @@ where
     }
 }
 
+#[doc(hidden)]
 pub fn extend_with_elements<T, U, E>(dest: &mut T, elements: U)
 where
     U: ExtendWithElements<E>,

--- a/crates/ratatui-kit/src/element/key.rs
+++ b/crates/ratatui-kit/src/element/key.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 //
 // 两个变体天然不互相碰撞;`Decl(同一 u128)` 与此前「无用户 key 用同一 decl_key」语义一致。
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[doc(hidden)]
 pub enum ElementKey {
     // 仅声明点稳定的 key,零堆分配。
     Decl(u128),

--- a/crates/ratatui-kit/src/element/mod.rs
+++ b/crates/ratatui-kit/src/element/mod.rs
@@ -8,6 +8,7 @@ pub use element_ext::{ElementExt, ElementRepr};
 mod extend_with_elements;
 pub use extend_with_elements::{ExtendWithElements, extend_with_elements};
 
+#[doc(hidden)]
 pub trait ElementType {
     type Props<'a>
     where

--- a/crates/ratatui-kit/src/hooks/use_effect.rs
+++ b/crates/ratatui-kit/src/hooks/use_effect.rs
@@ -22,6 +22,7 @@ pub trait UseEffect: private::Sealed {
         D: PartialEq + Unpin + 'static;
 }
 
+#[doc(hidden)]
 pub struct UseEffectImpl<D> {
     deps: Option<D>,
 }
@@ -32,6 +33,7 @@ impl<D> Default for UseEffectImpl<D> {
     }
 }
 
+#[doc(hidden)]
 pub struct UseAsyncEffectImpl<D> {
     f: Option<LocalBoxFuture<'static, ()>>,
     deps: Option<D>,

--- a/crates/ratatui-kit/src/hooks/use_future.rs
+++ b/crates/ratatui-kit/src/hooks/use_future.rs
@@ -17,6 +17,7 @@ pub trait UseFuture: private::Sealed {
         F: Future<Output = ()> + 'static;
 }
 
+#[doc(hidden)]
 pub struct UseFutureImpl {
     f: Option<LocalBoxFuture<'static, ()>>,
 }

--- a/crates/ratatui-kit/src/hooks/use_memo.rs
+++ b/crates/ratatui-kit/src/hooks/use_memo.rs
@@ -14,6 +14,7 @@ pub trait UseMemo: private::Sealed {
         T: Clone + Unpin + 'static;
 }
 
+#[doc(hidden)]
 pub struct UseMemoImpl<T, D> {
     memoized_value: Option<T>,
     deps: Option<D>,

--- a/crates/ratatui-kit/src/hooks/use_size.rs
+++ b/crates/ratatui-kit/src/hooks/use_size.rs
@@ -74,6 +74,7 @@ pub trait UsePreviousSize: private::Sealed {
     fn use_previous_size(&mut self) -> Rect;
 }
 
+#[doc(hidden)]
 pub struct UsePreviousSizeImpl {
     size: Rect,
 }

--- a/crates/ratatui-kit/src/input/mod.rs
+++ b/crates/ratatui-kit/src/input/mod.rs
@@ -39,6 +39,7 @@ pub enum EventPriority {
 // [`InputLayer`] 句柄仅在**同一帧**内由父组件传给子组件用于 [`EventScope::Layer`] 显式归属；
 // **禁止**存入 `use_state` 跨帧使用（下一帧该 id 已不在层栈，对应 handler 会静默失聪）。
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[doc(hidden)]
 pub struct LayerId(u64);
 
 // 用户持有的输入层句柄（`Copy`）。由 `use_input_layer` 返回。

--- a/crates/ratatui-kit/src/props.rs
+++ b/crates/ratatui-kit/src/props.rs
@@ -34,6 +34,7 @@ impl<T> DropRaw for DropRawImpl<T> {
 // raw: 指向实际数据的原始指针
 // drop: 可选的drop处理函数（对于owned类型）
 // _marker: 生命周期标记
+#[doc(hidden)]
 pub struct AnyProps<'a> {
     raw: *mut (),
     type_id: TypeId,

--- a/crates/ratatui-kit/src/reactive_handle.rs
+++ b/crates/ratatui-kit/src/reactive_handle.rs
@@ -11,6 +11,7 @@ use generational_box::{AnyStorage, GenerationalBox, Owner, SyncStorage};
 
 use crate::ElementKey;
 
+#[doc(hidden)]
 pub trait Notifier: Default + Send + Sync + 'static {
     fn wake(&mut self);
     fn register(&mut self, key: Option<&ElementKey>, waker: Waker);
@@ -68,6 +69,7 @@ impl Notifier for WakerMap {
     }
 }
 
+#[doc(hidden)]
 pub struct ReactiveValue<T, N> {
     value: T,
     notifier: N,

--- a/crates/ratatui-kit/src/render/tree.rs
+++ b/crates/ratatui-kit/src/render/tree.rs
@@ -23,6 +23,7 @@ impl Drop for RestoreGuard {
     }
 }
 
+#[doc(hidden)]
 pub struct Tree<'a> {
     root_component: InstantiatedComponent,
     props: AnyProps<'a>,

--- a/crates/ratatui-kit/src/terminal/mod.rs
+++ b/crates/ratatui-kit/src/terminal/mod.rs
@@ -73,6 +73,7 @@ where
 //
 // 事件订阅已移除（改由 `InputRuntime` 中央分发),故此 trait 仅暴露 update 真正用到的 `insert_before`
 // （闭包 box 化,因 `TerminalImpl::insert_before` 泛型闭包不对象安全)。
+#[doc(hidden)]
 pub trait UpdaterTerminal {
     fn insert_before(
         &mut self,

--- a/dev-notes/knowledge/macros-and-props.md
+++ b/dev-notes/knowledge/macros-and-props.md
@@ -152,9 +152,13 @@ ratatui 0.30 起 `Block` 内含 `Arc<dyn CellEffect>`（阴影效果的类型擦
 
 **踩过的坑**：`with_layout_style` 曾对注入字段用裸 `ratatui::layout::Margin` 等（6 处），而同宏 `layout_style()` 方法体却是对的 `::ratatui_kit::layout_style::`；调研第三方生态就绪度时用「只依赖 ratatui-kit 的外部 probe crate」一编译即暴露，已统一改为 `::ratatui_kit::ratatui::layout::*`。
 
-**正确做法**：改任何 `quote! { ... }` 里的类型/函数路径，一律写绝对 `::ratatui_kit::`；宏 hygiene 的回归护栏应是「一个只依赖 ratatui-kit 的外部 crate 跑 `cargo check`」或 `tests/ui/pass` 用例，别只靠库内编译判绿。
+**正确做法**：改任何 `quote! { ... }` 里的类型/函数路径，一律写绝对 `::ratatui_kit::`。
 
-**相关文件**：`crates/ratatui-kit-macros/src/with_layout_style.rs`、`crates/ratatui-kit/src/lib.rs`（`pub use ratatui` + `extern crate self`）
+**回归护栏必须用「只依赖 ratatui-kit 的独立 crate」，trybuild 抓不到**：`tests/ui/pass` 用例**不能**当 hygiene 护栏——trybuild 生成的临时 crate 会 mirror 被测 crate 的 dependencies/dev-dependencies（实测 `target/tests/trybuild/ratatui-kit-tests` 的 `Cargo.toml` 直接依赖 `ratatui`/`crossterm`），故其作用域里有裸 `ratatui`，宏即便回退成裸 `ratatui::layout::…` 也能解析、编译通过（**假绿**）。当初 `with_layout_style` 的 hygiene bug 就是因此长期没被 CI 发现。真正的外部视角护栏要用一个**只**声明 `ratatui-kit` 依赖（无 `ratatui`/`crossterm`）的 crate 跑 `cargo check`——本仓库以 workspace 成员 `crates/external-api-probe`（`publish = false`）承担这个角色，随 `--workspace` 自动编译，宏 hygiene 一回退就红。
+
+**同类:宏生成代码的 lint 也要自洽**：`with_layout_style` 生成的 `layout_style()` 里有 `..Default::default()`（只选部分布局字段时必要，全选时多余），会触发 `clippy::needless_update`。库内靠 `lib.rs` 顶部的 `#![allow(clippy::needless_update)]` 压住，但外部 crate 没有这个 crate 级 allow，`-D warnings` 就报错。已改为让宏在生成的 `layout_style()` 上自带 `#[allow(clippy::needless_update)]`。**原则:宏 `quote!` 出的代码不得依赖使用方 crate 级的 `#![allow(...)]` 或 lint 配置——需要的 allow 由宏自己带上。** 这类「外部才暴露」的问题正是 `external-api-probe` 护栏的价值。
+
+**相关文件**：`crates/ratatui-kit-macros/src/with_layout_style.rs`、`crates/ratatui-kit/src/lib.rs`（`pub use ratatui` + `extern crate self`）、`crates/external-api-probe/`（hygiene 护栏）
 
 ## 手写 Component 与 context-aware hooks
 

--- a/dev-notes/knowledge/macros-and-props.md
+++ b/dev-notes/knowledge/macros-and-props.md
@@ -146,6 +146,16 @@ ratatui 0.30 起 `Block` 内含 `Arc<dyn CellEffect>`（阴影效果的类型擦
 
 **相关文件**：`crates/ratatui-kit/src/lib.rs`
 
+### 宏 hygiene：所有宏展开须用绝对 `::ratatui_kit::` 路径，外部 crate 才能用
+
+过程宏面向**第三方组件 crate**（只依赖 `ratatui-kit`、作用域里没有 `ratatui`/`crossterm` 裸名）也要能用，故 `quote!` 生成的每一处路径都必须是绝对的：`::ratatui_kit::...`，需要 ratatui 类型时写 `::ratatui_kit::ratatui::...`（经 `lib.rs` 的 `pub use ratatui`）。**不得生成裸 `ratatui::` / `crossterm::` 路径**——库内因作用域有 `ratatui` 照常编译，外部 crate 会 `cannot find crate/module ratatui` 直接炸，而库内四件套永远发现不了。
+
+**踩过的坑**：`with_layout_style` 曾对注入字段用裸 `ratatui::layout::Margin` 等（6 处），而同宏 `layout_style()` 方法体却是对的 `::ratatui_kit::layout_style::`；调研第三方生态就绪度时用「只依赖 ratatui-kit 的外部 probe crate」一编译即暴露，已统一改为 `::ratatui_kit::ratatui::layout::*`。
+
+**正确做法**：改任何 `quote! { ... }` 里的类型/函数路径，一律写绝对 `::ratatui_kit::`；宏 hygiene 的回归护栏应是「一个只依赖 ratatui-kit 的外部 crate 跑 `cargo check`」或 `tests/ui/pass` 用例，别只靠库内编译判绿。
+
+**相关文件**：`crates/ratatui-kit-macros/src/with_layout_style.rs`、`crates/ratatui-kit/src/lib.rs`（`pub use ratatui` + `extern crate self`）
+
 ## 手写 Component 与 context-aware hooks
 
 ### Modal 等手写组件经 updater 拿 SystemContext 登记输入层

--- a/openspec/changes/third-party-component-ecosystem/.openspec.yaml
+++ b/openspec/changes/third-party-component-ecosystem/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/third-party-component-ecosystem/design.md
+++ b/openspec/changes/third-party-component-ecosystem/design.md
@@ -1,0 +1,63 @@
+## Context
+
+当前所有组件只能通过「合并进主仓库」进入生态,导致主库 `ratatui-kit` 无限膨胀,且每次 ratatui / 框架 breaking 都要连带维护大批内置组件。框架仍处 `0.x`、刚经历「三次重写」,动荡剧烈。
+
+已用一个「外部作者视角」的 probe crate 实证:框架公共 API 对第三方组件作者**已基本就绪**(手动 `impl Component`、`#[component]`、`element!`、`#[derive(Props)]`、`#[with_layout_style]`、`use_state`、自定义 `Hook` + `use_hook` 全部可用,架构无中央注册表),**唯一阻塞是 `#[with_layout_style]` 宏生成裸 `ratatui::layout::...` 路径**——外部 crate 作用域无 `ratatui` 名字即编译失败。
+
+约束(来自项目知识库):单线程渲染、框架级已移除 `Send + Sync` 强制、宏展开须用绝对 `::ratatui_kit::` 路径、feature 门控「改了模块没开 feature 就编译不到」、「编译即基线(example + doctest)」、发布走「打 tag → CI publish + git-cliff」。
+
+一次针对两个 PR 的多 agent 深度 review 佐证了本设计的几个判断:table(#11)完全满足 issue #10 且 CI 全绿;markdown(#12)携带 3 个实证 confirmed 的 correctness bug + 红 CI;且 review 独立发现官方 `Divider` 组件自己踩了「透明布局陷阱」(`#[with_layout_style]` 属性被静默忽略)——印证组件作者规范必须内建正确示范。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 解锁外部 crate 定义组件(修 `with_layout_style` 宏 hygiene)。
+- 确立并文档化「扩展 API 稳定面」契约,让第三方 crate 有稳定依赖面。
+- 产出组件作者规范 + `cargo-generate` 模板 + 命名/发布/发现约定。
+- 落地试点:table 入核心、markdown 迁出为独立 crate。
+
+**Non-Goals:**
+- 不重构现有组件的既有 API。
+- 不引入中央组件注册表 / 运行时插件动态加载(Rust 静态链接,组件即类型,无需)。
+- 本阶段不收窄 / 删除任何现有 `pub` 项(避免再叠加 breaking);稳定面仅文档化 + `#[doc(hidden)]` 标注。
+- 不建设 registry 后端服务(用 crates.io keyword + awesome-list 即足够)。
+
+## Decisions
+
+- **D1 宏路径修复用绝对 re-export 路径**:`with_layout_style` 注入字段类型改为 `::ratatui_kit::ratatui::layout::*`(经 lib.rs `pub use ratatui` 转发),而非要求外部 crate 自行 `use ratatui;`。理由:外部只依赖 `ratatui-kit`,避免 ratatui 版本双开;与同文件 `layout_style()` 方法体已有的 `::ratatui_kit::layout_style::` 风格一致。备选(要求外部依赖 ratatui)被否:强加依赖 + 版本地狱。
+
+- **D2 三层结构 + 官方 contrib monorepo**:核心 / `ratatui-kit-contrib`(官方扩展,各自独立 crate)/ 社区独立 crate。理由:主库瘦身(直接解决核心痛点),官方扩展集中便于统一 CI 与版本管理,社区去中心化零维护成本。备选被否:纯 monorepo 多 crate(代码仍在主仓库,未解决膨胀);纯去中心化(官方质量与发现失控)。
+
+- **D3 命名统一 `ratatui-kit-<name>` + keyword `ratatui-kit`**:理由:生态识别度(类 `bevy_`)、crates.io 搜索友好。风险 name squatting → 官方提前占用核心扩展名。备选被否:社区独立短前缀(与主品牌脱钩,新人难关联);scoped 包(Rust crates.io 无 scope)。
+
+- **D4 稳定面本阶段只文档化 + `#[doc(hidden)]`,不删 `pub` 项**:理由:`0.x` 已足够动荡,先立契约、避免再加 breaking;真正收窄 API 留后续独立 change 并标 BREAKING。
+
+- **D5 table 入核心 / markdown 迁出,且迁移前置修 bug**:判据「运行时 / 通用基础 → 核心;应用层重组件(依赖 pulldown-cmark / 语法高亮)→ 外置」。table 直接回应 issue #10 且 CI 全绿,作一等基础组件。markdown 迁出为 `ratatui-kit-markdown`,但 review 已实证其有 3 个 confirmed correctness bug(连续段落合并成一行、嵌套列表丢 bullet、标题样式泄漏)+ 红 CI + openspec 文档与实现不符——**这些 MUST 在迁移中一并修复并加回归测试**,否则等于把已知损坏的组件搬进生态。
+
+- **D6 发现用 crates.io keyword + `awesome-ratatui-kit`,不建 registry 服务**:理由:零维护、Rust 生态惯例。
+
+- **D7(待定) 宏 `crate = "..."` 逃生舱**:是否本阶段做。倾向:P0 可选——markdown 试点不 rename 依赖故非阻塞;但为长期健壮(防未来改名 / 使用方 rename)建议尽早补,归入 `extension-api-surface` 的宏 hygiene 延伸。
+
+## Risks / Trade-offs
+
+- **稳定面在 `0.x` 仍会 breaking** → 明确「`0.x` 的 semver:minor = breaking、patch = 新增」,外部用版本区间约束 + CHANGELOG 记录;把 probe 转正为「外部 crate 可编译」的持续验证(trybuild pass 用例或 contrib 里的最小 crate)。
+- **name squatting** → 官方提前注册核心扩展名(`ratatui-kit-table` 等)。
+- **contrib monorepo 版本协调成本** → 各 crate 独立版本 + 独立 tag 前缀,复用现有 CD 的按 tag 前缀定位 crate 机制。
+- **宏路径修复回归** → trybuild `pass`/`fail` + 四件套 `--all-features` + 新增外部编译验证。
+- **markdown 迁移暴露更多缺失扩展 API** → 视为预期收益(以战代练),缺什么补什么并回填稳定面清单。
+- **迁移带入未修 bug** → 把 review 实证的 3 个 confirmed bug 作为迁移**验收项**,不修不迁。
+
+## Migration Plan
+
+1. **P0 先落地**(修宏 + 稳定面文档),对现有用户零影响(库内 `ratatui` 仍可达)。
+2. **PR 合并顺序(review 已给专业结论,二者 git-stack 不可独立合)**:先合 #11(CI 绿、零验证存活 findings、单独即满足 issue #10);采纳 #12 对 `table/layout.rs` 的一行改动(Outer 模式 `column_count+1` 比 `2` 更正确,markdown 用 Grid 不受影响);#11 落地后 #12 rebase onto main,重复 table commit 自动 drop。
+3. **markdown 迁移**:在 `ratatui-kit-contrib` 建 `ratatui-kit-markdown`,搬入组件源码,依赖改为 crates.io `ratatui-kit` 版本区间;**先修 review 的 3 个 confirmed bug + 红 CI(clippy clone-on-Copy、rustfmt)+ openspec 文档对齐**,再随模板/规范一起发布;#12 PR 转为「不合入主库」并致谢作者。
+4. **回滚**:P0 宏修复若出问题,revert 单文件即可;文档 / 新仓库均为增量,无回滚风险。
+
+## Open Questions
+
+- 宏 `crate = "..."` 逃生舱是否纳入本阶段 P0?
+- `ratatui-kit-contrib` 用单一统一版本还是各 crate 独立版本?(倾向独立)
+- 核心该保留哪些一等组件、哪些下沉社区?(本 change 只处理 table 入核、markdown 出;其余组件盘点另议)
+- PR #12 作者(KonghaYao)是否愿意以独立 crate 形式维护 markdown,还是由官方接管进 contrib?
+- `table/layout.rs` Outer 模式 `render_row_line` 与 `render_border_line` 的深层不一致是否顺带修(review 标为可选 follow-up)?

--- a/openspec/changes/third-party-component-ecosystem/proposal.md
+++ b/openspec/changes/third-party-component-ecosystem/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+组件目前只能通过「合并进主仓库」的方式进入生态,导致主库 `ratatui-kit` 无限膨胀,且每次 ratatui / 框架 breaking 都要连带维护一大批内置组件,不可持续。当前只有两个待处理 PR(#11 table、#12 markdown 生态),是确立「第三方组件各自发 crate、无需合主仓库」生态的最低成本时机。
+
+已用一个「外部作者视角」的 probe crate 实证:框架公共 API 对第三方组件作者**已基本就绪**(手动 `impl Component`、`#[component]`、`element!`、`#[derive(Props)]`、`#[with_layout_style]`、`use_state`、自定义 `Hook` + `use_hook` 全部可用,架构无中央注册表),**唯一阻塞是一个宏路径 bug**。也就是说,这套生态技术上现在就能走通,缺的是一层稳定契约 + 规范 + 发现机制。
+
+## What Changes
+
+- **[P0]** 修复 `#[with_layout_style]` 宏展开生成裸 `ratatui::layout::...` 路径的 bug(6 处),改为绝对路径 `::ratatui_kit::ratatui::layout::...`,使外部 crate 无需自行依赖 `ratatui` 即可获得标准布局能力。这是解锁整个生态的前置阻塞项。
+- **[P0]** 确立并文档化「扩展 API 稳定面(Extension API Surface)」:明确哪些公共项对第三方组件作者承诺 semver;内部实现项(如 `ComponentHelperExt`、`AnyProps`)显式标注 internal / `#[doc(hidden)]`。本阶段只做文档化与标注,**不删除现有 `pub` 项**(避免 breaking)。
+- **[P0,可选]** 给 `#[component]` / `element!` / `#[derive(Props)]` / `#[with_layout_style]` 增加 `crate = "..."` 逃生舱,防止使用方 `cargo` rename 依赖时宏路径失效。
+- **[P1]** 发布第三方组件作者规范 `COMPONENT_GUIDE.md` + `cargo-generate` 模板仓库 `ratatui-kit-component-template`。
+- **[P1]** 确立生态三层结构与命名/发现规范:核心 / 官方扩展(`ratatui-kit-contrib` monorepo)/ 社区独立 crate;统一命名前缀 `ratatui-kit-<name>` + crates.io keyword `ratatui-kit` + `awesome-ratatui-kit` 列表 + 主库 README「Ecosystem」段。
+- **[P2]** 落地试点:PR #11 table 合入核心;PR #12 markdown 生态抽成独立 crate `ratatui-kit-markdown` 端到端跑通(以此逼出所有仍缺失的扩展 API)。
+
+不含破坏性变更:`with_layout_style` 路径修复对库内既有用法无影响(库内 `ratatui` 仍可达),外部则由「不可用」变「可用」;稳定面本阶段仅文档化与 `#[doc(hidden)]` 标注,不移除任何现有 `pub` 项。未来若要收窄 API 表面(真正删除/隐藏外部可能已用的项),另立 change 并标注 **BREAKING**。
+
+## Capabilities
+
+### New Capabilities
+- `extension-api-surface`: 框架侧对第三方组件作者承诺稳定(遵守 semver)的公共扩展 API 契约,以及过程宏必须使用绝对路径(hygiene)、可在外部 crate 中编译通过的要求。
+- `component-authoring`: 第三方组件 / 自定义 hook 作者应遵循的契约与约定(只依赖公共 API、透明布局、feature 门控、panic 文案英文、doctest+example 编译基线、声明兼容版本区间),及配套 `cargo-generate` 模板。
+- `ecosystem-conventions`: 生态治理约定——三层结构(核心 / 官方扩展 / 社区)、crate 命名前缀 `ratatui-kit-<name>`、crates.io keyword 与发布流程、`awesome-ratatui-kit` 发现机制。
+
+### Modified Capabilities
+<!-- 无:本 change 全部为新增能力。with_layout_style 的宏路径修复归入 extension-api-surface 的宏 hygiene 要求,不修改现有 spec 的既有 requirement。 -->
+
+## Impact
+
+- **代码**:`crates/ratatui-kit-macros/src/with_layout_style.rs`(宏路径修复);可能触及 `crates/ratatui-kit/src/lib.rs`(re-export / `#[doc(hidden)]` 标注)、`crates/ratatui-kit-macros/src/{component,element,props}.rs`(`crate =` 逃生舱)。
+- **回归护栏**:四件套 `--all-features`(test/clippy/fmt/doc)+ `crates/ratatui-kit/tests/ui/{pass,fail}` trybuild;新增一个「外部 crate 编译」层面的验证(probe 转正为 UI/集成测试或文档示例)。
+- **新增仓库 / 交付物**:`ratatui-kit-contrib`(官方扩展 monorepo)、`ratatui-kit-component-template`(cargo-generate)、`awesome-ratatui-kit`;`COMPONENT_GUIDE.md`、扩展 API 稳定面文档、README「Ecosystem」段。
+- **发布 / 依赖**:crates.io keyword/category 约定,复用现有「打 tag → CI publish + git-cliff」流程。
+- **PR 处置**:#11 合入主库核心;#12 迁出为 `ratatui-kit-markdown` 独立 crate。

--- a/openspec/changes/third-party-component-ecosystem/specs/component-authoring/spec.md
+++ b/openspec/changes/third-party-component-ecosystem/specs/component-authoring/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: 组件作者只依赖公共扩展 API
+
+第三方组件 crate MUST 仅依赖 `ratatui-kit` 扩展 API 稳定面中的项,不得依赖标注为 internal 的实现项;需要 ratatui / crossterm 类型时 MUST 经 `ratatui_kit::ratatui` / `ratatui_kit::crossterm` re-export 获取,不单独声明 `ratatui` 依赖,以避免版本双开。
+
+#### Scenario: 获取 ratatui 类型
+
+- **WHEN** 组件需要 `Constraint`、`Style` 等 ratatui 类型
+- **THEN** 经 `ratatui_kit::ratatui::...` 引用,`Cargo.toml` 不单独声明 `ratatui` 依赖
+
+### Requirement: 透明布局约定
+
+使用 `#[component]` 的函数组件作者 MUST 将布局属性(gap / flex_direction / width / height 等)写在返回的根元素上,因为函数组件是透明布局包装器、本身不占独立布局节点。
+
+#### Scenario: 函数组件设置布局
+
+- **WHEN** 作者希望自定义函数组件支持布局属性
+- **THEN** 在返回的根 `element!` 元素上设置布局属性,而非期望包装器本身承载
+
+### Requirement: feature 门控与最小默认
+
+会引入额外依赖的组件能力 MUST 通过 Cargo feature 门控,可选依赖绑定到对应 feature,默认 feature 保持最小。
+
+#### Scenario: 门控重依赖
+
+- **WHEN** 组件依赖如语法高亮、正则等重量级 crate
+- **THEN** 该依赖声明为 `optional = true` 并绑定到对应 feature,默认不启用
+
+### Requirement: 面向使用者的运行时文案用英文
+
+组件触发的、面向库使用者的 panic / expect / 错误文案 MUST 使用英文(国际化);源码注释可用中文。
+
+#### Scenario: 运行时 panic
+
+- **WHEN** 组件因误用触发面向使用者的 panic 或 expect
+- **THEN** 其文案为英文
+
+### Requirement: 编译即基线与版本区间声明
+
+组件 crate MUST 保证其所有 example 与 doctest 能编译通过,并在 `Cargo.toml` 中以版本区间约束 `ratatui-kit`(匹配所依赖的扩展 API 稳定面版本)。
+
+#### Scenario: CI 编译基线
+
+- **WHEN** 组件 crate 的 CI 运行
+- **THEN** 所有 example 与 doctest 编译通过
+
+#### Scenario: 声明兼容版本区间
+
+- **WHEN** 发布组件 crate
+- **THEN** `Cargo.toml` 用版本区间(如 `ratatui-kit = ">=0.7, <0.8"`)约束依赖,而非无上界的开放版本
+
+### Requirement: 提供 cargo-generate 起步模板
+
+生态 MUST 提供 `ratatui-kit-component-template`,预置一个示例组件、一个自定义 hook、可运行的最小 example、fmt/clippy/test/doc CI 与「打 tag 发布」配置。
+
+#### Scenario: 新作者起步
+
+- **WHEN** 新作者用 `cargo generate` 该模板创建组件 crate
+- **THEN** 得到开箱即用的骨架,`cargo build` 与 `cargo run --example` 直接成功,且 CI 与发布配置齐备

--- a/openspec/changes/third-party-component-ecosystem/specs/ecosystem-conventions/spec.md
+++ b/openspec/changes/third-party-component-ecosystem/specs/ecosystem-conventions/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: 三层生态结构
+
+生态 MUST 分为三层:核心 `ratatui-kit`(主仓库,承载运行时与一等基础组件)、官方扩展(集中于 `ratatui-kit-contrib` monorepo,各组件为独立发布的 crate)、社区独立 crate。组件归属 MUST 按判据划分:运行时 / 通用基础能力归核心;官方维护的高质量扩展归 contrib;其余归社区。
+
+#### Scenario: 判定组件归属
+
+- **WHEN** 决定一个新组件放在哪一层
+- **THEN** 按「运行时 / 通用基础 → 核心;官方维护的高质量扩展 → contrib;其余 → 社区」归位,而非默认合入主库
+
+### Requirement: crate 命名前缀与 keyword
+
+官方扩展 crate MUST 命名为 `ratatui-kit-<name>`;社区第三方 crate SHALL 采用同一 `ratatui-kit-<name>` 前缀。所有生态 crate MUST 携带 crates.io keyword `ratatui-kit`;官方维护的 crate MUST 在 description 中标注 `official`。
+
+#### Scenario: 发布命名
+
+- **WHEN** 发布一个表格组件 crate
+- **THEN** 命名为 `ratatui-kit-<name>`,`keywords` 含 `ratatui-kit`
+
+#### Scenario: 区分官方与社区
+
+- **WHEN** 用户在 crates.io 检视一个 `ratatui-kit-*` crate
+- **THEN** 官方维护的在 description 标 `official`,社区的不标,二者可区分
+
+### Requirement: 发现机制
+
+生态 MUST 提供 `awesome-ratatui-kit` 列表汇总可用组件;主库 README MUST 含「Ecosystem」段指向该列表与 keyword 检索方式。
+
+#### Scenario: 用户查找可用组件
+
+- **WHEN** 用户想找一个现成的组件
+- **THEN** 可经 crates.io keyword `ratatui-kit` 或 `awesome-ratatui-kit` 列表发现
+
+### Requirement: 发布流程复用
+
+官方扩展 crate 的发布 MUST 复用主库「改版本 → 打 tag → CI 校验版本一致并 cargo publish + git-cliff 生成 CHANGELOG」流程。
+
+#### Scenario: 发布官方扩展
+
+- **WHEN** 官方扩展 crate 升版本并打 tag
+- **THEN** CI 校验 `Cargo.toml` 版本与 tag 一致后 `cargo publish`,不一致则失败
+
+### Requirement: 试点落地
+
+本 change 的试点 MUST 为:PR #11 table 作为一等基础组件(feature 门控)合入主库核心;PR #12 markdown 生态迁出为独立 crate `ratatui-kit-markdown`(置于 contrib),且只依赖扩展 API 稳定面。
+
+#### Scenario: table 归核心
+
+- **WHEN** 处理 PR #11
+- **THEN** table 以 feature 门控形式合入主库核心
+
+#### Scenario: markdown 独立
+
+- **WHEN** 处理 PR #12
+- **THEN** markdown 生态迁出为 `ratatui-kit-markdown`,不合入主库,仅依赖公共扩展 API

--- a/openspec/changes/third-party-component-ecosystem/specs/extension-api-surface/spec.md
+++ b/openspec/changes/third-party-component-ecosystem/specs/extension-api-surface/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: 过程宏在外部 crate 中可编译(宏 hygiene)
+
+所有导出的过程宏(`#[component]`、`element!`、`#[derive(Props)]`、`#[with_layout_style]`、`routes!`)展开时 MUST 只引用绝对路径 `::ratatui_kit::...`(需要 ratatui / crossterm 类型时经 `::ratatui_kit::ratatui` / `::ratatui_kit::crossterm` re-export 转发),不得生成任何依赖「调用方作用域内存在裸 `ratatui` / `crossterm` crate 名」的代码。
+
+#### Scenario: 外部 crate 使用 #[with_layout_style]
+
+- **WHEN** 一个仅依赖 `ratatui-kit`(不直接依赖 `ratatui`)的外部 crate 对具名字段结构体应用 `#[with_layout_style]`
+- **THEN** 该 crate 编译通过,注入的 `margin`/`offset`/`width`/`height`/`flex_direction`/`justify_content` 字段类型全部解析到 `::ratatui_kit::ratatui::layout::*`
+
+#### Scenario: 外部 crate 组合使用全部宏
+
+- **WHEN** 外部 crate 用 `#[component]` + `element!` + `#[derive(Props)]` 定义一个组件
+- **THEN** 编译通过,不出现「cannot find module or crate」类路径错误
+
+### Requirement: 扩展 API 稳定面文档化
+
+框架 MUST 提供一份文档,枚举对第三方组件作者承诺遵守 semver 的公共项(扩展 API 稳定面),并将非承诺的内部实现项标注为 internal 或 `#[doc(hidden)]`。稳定面至少 MUST 覆盖:组件契约(`Component`、`ComponentUpdater`、`ComponentDrawer`、`Element`、`AnyElement`、`ElementKey`、`NoProps`)、过程宏、Hooks(`Hooks`、`Hook`、`use_hook` 及内置 hooks)、状态与布局(`State`、`LayoutStyle`)、re-export(`ratatui`、`crossterm`)。
+
+#### Scenario: 作者查阅稳定面
+
+- **WHEN** 组件作者阅读扩展 API 文档
+- **THEN** 能明确区分哪些项承诺稳定可依赖、哪些是内部实现不应依赖
+
+#### Scenario: 内部项标注
+
+- **WHEN** 检视 `ComponentHelperExt`、`AnyProps` 等内部实现项
+- **THEN** 它们被标注为 internal(文档说明或 `#[doc(hidden)]`),不列入稳定面清单
+
+### Requirement: 稳定面变更遵守 semver
+
+在 `0.x` 阶段,移除或不兼容地修改稳定面中的项 MUST 伴随 minor 版本号提升并记入 CHANGELOG;纯新增项可随 patch 版本发布。
+
+#### Scenario: 收窄稳定面
+
+- **WHEN** 需要移除或隐藏一个已列入稳定面的公共项
+- **THEN** 该变更通过独立 change 提出、标注 BREAKING、并提升 minor 版本号

--- a/openspec/changes/third-party-component-ecosystem/tasks.md
+++ b/openspec/changes/third-party-component-ecosystem/tasks.md
@@ -1,10 +1,10 @@
 ## 1. P0 — 扩展 API 地基(阻塞项,立即可做)
 
-- [ ] 1.1 修复 `crates/ratatui-kit-macros/src/with_layout_style.rs` 第 54-72 行 6 处裸 `ratatui::layout::...`,改为 `::ratatui_kit::ratatui::layout::...`(margin/offset/width/height/flex_direction/justify_content)
-- [ ] 1.2 回归验证:四件套 `--all-features`(test/clippy `-D warnings`/fmt --check/doc `RUSTDOCFLAGS=-D warnings`)+ `crates/ratatui-kit/tests/ui/{pass,fail}` trybuild 全绿
-- [ ] 1.3 新增「外部 crate 可编译」验证:把 probe 转正为 `tests/ui/pass` 用例或 contrib 内最小 crate,锁死宏 hygiene 回归
-- [ ] 1.4 起草「扩展 API 稳定面」文档:枚举承诺 semver 的公共项(Component/ComponentUpdater/ComponentDrawer/Element/AnyElement/ElementKey/NoProps、过程宏、Hooks/Hook/use_hook+内置 hooks、State/LayoutStyle、re-export ratatui/crossterm)
-- [ ] 1.5 给内部实现项(`ComponentHelperExt`、`AnyProps` 等)加 `#[doc(hidden)]` 或文档 internal 标注,不删除现有 `pub` 项
+- [x] 1.1 修复 `crates/ratatui-kit-macros/src/with_layout_style.rs` 第 54-72 行 6 处裸 `ratatui::layout::...`,改为 `::ratatui_kit::ratatui::layout::...`(margin/offset/width/height/flex_direction/justify_content)
+- [x] 1.2 回归验证:四件套 `--all-features`(test/clippy `-D warnings`/fmt --check/doc `RUSTDOCFLAGS=-D warnings`)+ `crates/ratatui-kit/tests/ui/{pass,fail}` trybuild 全绿
+- [x] 1.3 新增「外部 crate 可编译」验证:把 probe 转正为 `tests/ui/pass` 用例或 contrib 内最小 crate,锁死宏 hygiene 回归
+- [x] 1.4 起草「扩展 API 稳定面」文档:枚举承诺 semver 的公共项(Component/ComponentUpdater/ComponentDrawer/Element/AnyElement/ElementKey/NoProps、过程宏、Hooks/Hook/use_hook+内置 hooks、State/LayoutStyle、re-export ratatui/crossterm)
+- [x] 1.5 给内部实现项(`ComponentHelperExt`、`AnyProps` 等)加 `#[doc(hidden)]` 或文档 internal 标注,不删除现有 `pub` 项
 - [ ] 1.6 (可选)为 `#[component]`/`element!`/`#[derive(Props)]`/`#[with_layout_style]` 增加 `crate = "..."` 逃生舱,防依赖 rename
 
 ## 2. P1 — 作者规范 + 模板 + 发现机制

--- a/openspec/changes/third-party-component-ecosystem/tasks.md
+++ b/openspec/changes/third-party-component-ecosystem/tasks.md
@@ -1,0 +1,37 @@
+## 1. P0 — 扩展 API 地基(阻塞项,立即可做)
+
+- [ ] 1.1 修复 `crates/ratatui-kit-macros/src/with_layout_style.rs` 第 54-72 行 6 处裸 `ratatui::layout::...`,改为 `::ratatui_kit::ratatui::layout::...`(margin/offset/width/height/flex_direction/justify_content)
+- [ ] 1.2 回归验证:四件套 `--all-features`(test/clippy `-D warnings`/fmt --check/doc `RUSTDOCFLAGS=-D warnings`)+ `crates/ratatui-kit/tests/ui/{pass,fail}` trybuild 全绿
+- [ ] 1.3 新增「外部 crate 可编译」验证:把 probe 转正为 `tests/ui/pass` 用例或 contrib 内最小 crate,锁死宏 hygiene 回归
+- [ ] 1.4 起草「扩展 API 稳定面」文档:枚举承诺 semver 的公共项(Component/ComponentUpdater/ComponentDrawer/Element/AnyElement/ElementKey/NoProps、过程宏、Hooks/Hook/use_hook+内置 hooks、State/LayoutStyle、re-export ratatui/crossterm)
+- [ ] 1.5 给内部实现项(`ComponentHelperExt`、`AnyProps` 等)加 `#[doc(hidden)]` 或文档 internal 标注,不删除现有 `pub` 项
+- [ ] 1.6 (可选)为 `#[component]`/`element!`/`#[derive(Props)]`/`#[with_layout_style]` 增加 `crate = "..."` 逃生舱,防依赖 rename
+
+## 2. P1 — 作者规范 + 模板 + 发现机制
+
+- [ ] 2.1 编写 `COMPONENT_GUIDE.md`:组件契约(只依赖公共 API、透明布局陷阱、feature 门控、panic 文案英文、doctest+example 编译基线、版本区间声明)
+- [ ] 2.2 编写命名 + 发布规范:`ratatui-kit-<name>` 前缀、keyword `ratatui-kit`、category、official 标注、打 tag 发布流程
+- [ ] 2.3 创建 `ratatui-kit-component-template`(cargo-generate):示例组件 + 自定义 hook + 可运行 example + fmt/clippy/test/doc CI + 打 tag 发布配置(内建透明布局正确示范)
+- [ ] 2.4 主库 README 增加「Ecosystem」段,指向 awesome-list 与 keyword 检索
+- [ ] 2.5 创建 `awesome-ratatui-kit` 列表仓库骨架
+- [ ] 2.6 创建 `ratatui-kit-contrib` monorepo 骨架(workspace + CI + 按 tag 前缀发布)
+
+## 3. P2 — 试点:table 入核心
+
+- [ ] 3.1 合入 PR #11(CI 绿、零验证存活 findings、单独满足 issue #10)
+- [ ] 3.2 采纳 #12 对 `table/layout.rs` 的 Outer 模式修复(`column_count+1`,防 Outer 边框越界;markdown 用 Grid 不受影响),折入 #11 或接受 #12 rebase 带入
+
+## 4. P2 — 试点:markdown 迁出为独立 crate(迁移即修 review 实证 bug)
+
+- [ ] 4.1 在 contrib 建 `ratatui-kit-markdown` crate,搬入 markdown/code_block/diff/blockquote/divider 源码,依赖改为 crates.io `ratatui-kit` 版本区间
+- [ ] 4.2 修 **blocker**:连续段落合并成一行(`parser.rs` flush_spans 把每次 flush 并入前一 Paragraph)——按行分行渲染 + 段间空行 + 硬换行成真换行,加回归测试
+- [ ] 4.3 修 **major**:嵌套列表父项丢 bullet + 多余空 bullet(子列表 Start 时把父项已收集 spans 作为 ListItem 发出,跳过空 ListItem),加回归测试
+- [ ] 4.4 修 **CI blocker**:删 `examples/components/markdown_streaming.rs` 6 处对 Copy 类型(State/ReactiveHandle)的 `.clone()`,并 `cargo fmt --all`(markdown/mod.rs、parser.rs、markdown_streaming.rs)
+- [ ] 4.5 修 minor:标题内 bold/italic 样式泄漏(改用 save/restore 样式栈,同 link 路径);代码块与换行表格行的预留高度按 wrap 感知计算(避免 ScrollView 裁剪);Divider 透明布局属性转发到根元素;补齐 4 处 `///` doctest 缺失的 prelude import
+- [ ] 4.6 对齐 openspec 文档(#12 自带 md-diff-highlight-components change:MarkdownComponents trait / 三层 LRU 缓存等描述与实现不符,勾选状态与实现对齐或改写)
+- [ ] 4.7 端到端验证:markdown crate 全部 example 跑通 + 编译基线 + 全量四件套,然后发布首个版本
+
+## 5. 收尾
+
+- [ ] 5.1 回填 markdown 迁移中暴露的缺失扩展 API 到稳定面文档
+- [ ] 5.2 `openspec archive third-party-component-ecosystem`


### PR DESCRIPTION
## 背景

建立第三方组件生态的第一块地基(openspec change: `third-party-component-ecosystem`)。用一个「外部作者视角」的 probe crate 实证:框架公共 API 对第三方组件作者**已基本就绪**(手动 `impl Component`、`#[component]`、`element!`、`#[derive(Props)]`、`#[with_layout_style]`、`use_state`、自定义 `Hook`+`use_hook` 全部可用,架构无中央注册表),唯一阻塞是 `#[with_layout_style]` 宏生成裸 `ratatui::` 路径。

## 本 PR 内容(P0 地基)

- **fix(macros)**:`with_layout_style` 注入字段类型 6 处裸 `ratatui::layout::...` → `::ratatui_kit::ratatui::layout::...`。外部 crate(只依赖 `ratatui-kit`、作用域无 `ratatui` 裸名)从此无需自行依赖 `ratatui` 即可用标准布局能力,避免 ratatui 版本双开。
- **docs(openspec)**:立项 `third-party-component-ecosystem`(proposal / design / 3 specs / tasks),定义扩展 API 稳定面、组件作者规范、生态治理约定与 P0/P1/P2 路线。
- **docs(dev-notes)**:记录「宏 hygiene:宏展开须用绝对 `::ratatui_kit::` 路径」踩坑。

## 验证

- probe 去掉临时绕过后**原生编译通过**(证明外部 crate 可用)。
- 四件套 `--all-features`(clippy `-D warnings` / fmt --check / test / doc `RUSTDOCFLAGS=-D warnings`)+ `tests/ui` trybuild 全绿,**零回归**。

## 后续(同分支陆续补 P0 收尾)

- [ ] 起草「扩展 API 稳定面」文档 + 给内部实现项标 `#[doc(hidden)]`
- [ ] 将 probe 转正为 `tests/ui/pass` 回归护栏,锁死宏 hygiene

Refs: #10, #11, #12
