### PR TITLE
feat: add auto_quit_on_ctrl_c flag to SystemContext

### DIFF
--- a/crates/ratatui-kit/src/context.rs
+++ b/crates/ratatui-kit/src/context.rs
@@ -158,6 +158,10 @@ impl<'a> ContextStack<'a> {
 
 pub struct SystemContext {
     should_exit: bool,
+    /// 收到 Ctrl+C 键盘事件时是否自动退出 fullscreen event loop。
+    /// 默认 true（向后兼容）。若设为 false，Ctrl+C 仍会经 input.dispatch 分发给
+    /// Global handler，由应用层自行决定行为（如双击退出、取消 agent 等）。
+    pub auto_quit_on_ctrl_c: bool,
     // 中央输入事件运行时。组件经 `get_context_mut::<SystemContext>().input` 登记层/handler,
     // 渲染循环经 `system_context.input.dispatch(event)` 分发。运行时单线程,无需 Send + Sync。
     pub(crate) input: crate::input::InputRuntime,
@@ -167,6 +171,7 @@ impl SystemContext {
     pub(crate) fn new() -> Self {
         Self {
             should_exit: false,
+            auto_quit_on_ctrl_c: true, // 默认 true，保持向后兼容
             input: crate::input::InputRuntime::default(),
         }
     }

--- a/crates/ratatui-kit/src/render/tree.rs
+++ b/crates/ratatui-kit/src/render/tree.rs
@@ -87,8 +87,12 @@ impl<'a> Tree<'a> {
                 Either::Left(((), _)) => continue,
                 // 取到一个 raw 事件。
                 Either::Right((Some(event), _)) => {
-                    // ctrl_c 先于 dispatch 判定,任何层的 Consumed 都吞不掉它。
-                    if CrossTerminal::received_ctrl_c(event.clone()) {
+                    // Ctrl+C: 仅当 SystemContext.auto_quit_on_ctrl_c 为 true 时无条件退出。
+                    // 应用层可通过 system_ctx.auto_quit_on_ctrl_c = false 自行管理
+                    // Ctrl+C 行为（如三级优先级链：双击退出、取消 agent 等）。
+                    if self.system_context.auto_quit_on_ctrl_c
+                        && CrossTerminal::received_ctrl_c(event.clone())
+                    {
                         break;
                     }
                     self.system_context.input.dispatch(event);


### PR DESCRIPTION
SystemContext now has `auto_quit_on_ctrl_c` field (default true for backward compatibility). When set to false, Ctrl+C keyboard events are dispatched to the Global handler instead of unconditionally breaking the fullscreen event loop. This allows applications (e.g. peri-tui) to implement custom Ctrl+C behavior (double-press quit, agent cancel, etc).

简单说，应用层想要实现 ctrl + c 连续两次才关闭， 需要添加这个 flag，来给应用层自定义；